### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ internal fun App() {
 
 <img src="readme_images/text_field_added.png" height="200px">
 
+Note that all @Composable functions in the shared/src folder should be `internal`.
+
 ### Configuring the iOS application
 
 This template contains a `iosApp/Configuration/Config.xcconfig` configuration file that allows you to configure most basic properties without having to move to Xcode. It contains:


### PR DESCRIPTION
Added the note about functions inside shared module. The function must be internal, becaous public @Composable function broken the compile of ios project. 

Therefore, adding a note about this in the project's documentation or README file can be helpful for other developers who may encounter the same issue.