### PR TITLE
Add configChanges to AndroidManifest.xml to prevent activity recreation

### DIFF
--- a/androidApp/src/androidMain/AndroidManifest.xml
+++ b/androidApp/src/androidMain/AndroidManifest.xml
@@ -10,6 +10,7 @@
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">
         <activity
             android:exported="true"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
             android:name=".MainActivity"
         >
             <intent-filter>


### PR DESCRIPTION
Ensures that the Compose Android activity isn't recreated when the device is e.g. rotated – Compose takes care of that internally.