### PR TITLE
Update androidTarget

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
     sourceSets {
         val androidMain by getting {
             dependencies {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 kotlin {
-    android()
+    androidTarget()
 
     jvm("desktop")
 


### PR DESCRIPTION
As of Kotlin 1.9.0, 'android()' is now deprecated. 'androidTarget()' can be used instead.