### PR TITLE
Clean Xcode warning

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -156,6 +156,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		05D91A922A5F233C00F138EB /* Compile Kotlin */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
Previous configuration produces the warning `Run script build phase 'Compile Kotlin' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase.`, so the solution was to uncheck the proper box in Xcode UI.

The warning is visible on the presented screenshot and was visible in Report navigator tab in Xcode.
<img width="839" alt="Screenshot 2023-09-28 at 22 14 40" src="https://github.com/JetBrains/compose-multiplatform-template/assets/11787040/d64354b3-062c-4c6b-bc16-1eaae2923c06">

