### PR TITLE
Add contentDescription to the Image

### DIFF
--- a/shared/src/commonMain/kotlin/App.kt
+++ b/shared/src/commonMain/kotlin/App.kt
@@ -31,7 +31,7 @@ fun App() {
             AnimatedVisibility(showImage) {
                 Image(
                     painterResource("compose-multiplatform.xml"),
-                    null
+                    contentDescription = "Compose Multiplatform icon"
                 )
             }
         }


### PR DESCRIPTION
It is advised to set it for accessibility purposes: https://developer.android.com/jetpack/compose/accessibility#describe-visual

(also, it is a required parameter)