### PR TITLE
Update Android Gradle Plugin version to 8.1.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@ android.minSdk=24
 
 #Versions
 kotlin.version=1.9.20
-agp.version=8.0.2
+agp.version=8.1.2
 compose.version=1.5.10


### PR DESCRIPTION
Since we are targeting androidSdk 34 which has not tested with agp 8.0.2 version it makes sense to upgrade to the latest version, I already sent a pull request to the compose multiplatform mobile template