### PR TITLE
remove CocoaPods from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ To work with this template, you need the following:
 * [Xcode](https://apps.apple.com/us/app/xcode/id497799835)
 * [Android Studio](https://developer.android.com/studio)
 * The [Kotlin Multiplatform Mobile plugin](https://plugins.jetbrains.com/plugin/14936-kotlin-multiplatform-mobile)
-* The [CocoaPods dependency manager](https://kotlinlang.org/docs/native-cocoapods.html)
 
 ### Check your environment
 


### PR DESCRIPTION
We don't need a step with CocoaPods in README